### PR TITLE
refs #913 Use HelmRelease for kube-state-metrics

### DIFF
--- a/external-prd/resources/helm.yaml
+++ b/external-prd/resources/helm.yaml
@@ -2,6 +2,30 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
+  name: kube-state-metrics
+  namespace: flux-system
+spec:
+  interval: 1m
+  targetNamespace: monitoring
+  chart:
+    spec:
+      chart: kube-state-metrics
+      version: '5.7.0'
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      interval: 1m
+  values:
+    service:
+      port: 8080
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '8080'
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
   name: node-manager
   namespace: flux-system
 spec:


### PR DESCRIPTION
refs #913 