### PR TITLE
[raspberry] Remove kube-state-metrics

### DIFF
--- a/raspberry/resources/helm.yaml
+++ b/raspberry/resources/helm.yaml
@@ -16,27 +16,3 @@ spec:
         name: metallb
         namespace: flux-system
       interval: 1m
----
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
-kind: HelmRelease
-metadata:
-  name: kube-state-metrics
-  namespace: flux-system
-spec:
-  interval: 1m
-  targetNamespace: monitoring
-  chart:
-    spec:
-      chart: kube-state-metrics
-      version: '5.8.0'
-      sourceRef:
-        kind: HelmRepository
-        name: prometheus-community
-        namespace: flux-system
-      interval: 1m
-  values:
-    service:
-      port: 8080
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'


### PR DESCRIPTION
because it will be installed with prometheus helm chart