### PR TITLE
[raspberry] Reinstall longhorn with 1.4.2

### DIFF
--- a/raspberry/resources/helm.yaml
+++ b/raspberry/resources/helm.yaml
@@ -41,27 +41,27 @@ spec:
   values:
     installCRDs: true
 ---
-# apiVersion: helm.toolkit.fluxcd.io/v2beta1
-# kind: HelmRelease
-# metadata:
-#   name: longhorn
-#   namespace: flux-system
-# spec:
-#   interval: 1m
-#   targetNamespace: longhorn-system
-#   chart:
-#     spec:
-#       chart: longhorn
-#       version: '1.5.0'
-#       sourceRef:
-#         kind: HelmRepository
-#         name: longhorn
-#         namespace: flux-system
-#       interval: 1m
-#   values:
-#     service:
-#       ui:
-#         type: LoadBalancer
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: longhorn
+  namespace: flux-system
+spec:
+  interval: 1m
+  targetNamespace: longhorn-system
+  chart:
+    spec:
+      chart: longhorn
+      version: '1.4.2'
+      sourceRef:
+        kind: HelmRepository
+        name: longhorn
+        namespace: flux-system
+      interval: 1m
+  values:
+    service:
+      ui:
+        type: LoadBalancer
 ---
 # apiVersion: helm.toolkit.fluxcd.io/v2beta1
 # kind: HelmRelease


### PR DESCRIPTION
Because 1.5.0 has a bug.
```
panic: unrecognized command: conversion-webhook
```