### PR TITLE
Revert "raspberry: Update Helm release metallb to v0.13.11"

### DIFF
--- a/raspberry/resources/helm.yaml
+++ b/raspberry/resources/helm.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: metallb
-      version: '0.13.11'
+      version: '0.13.10'
       sourceRef:
         kind: HelmRepository
         name: metallb


### PR DESCRIPTION
Reverts h3poteto/k8s-services#1256