### PR TITLE
Revert "external-prd: Update Helm release kube-state-metrics to v5.29.0"

### DIFF
--- a/external-prd/resources/helm.yaml
+++ b/external-prd/resources/helm.yaml
@@ -86,7 +86,7 @@ spec:
   chart:
     spec:
       chart: kube-state-metrics
-      version: '5.29.0'
+      version: '5.28.0'
       sourceRef:
         kind: HelmRepository
         name: prometheus-community


### PR DESCRIPTION
Reverts h3poteto/k8s-services#2302